### PR TITLE
Support for Blox.pl blogging platform in kate_mac themes

### DIFF
--- a/chrome-killfile-extension/manifest.json
+++ b/chrome-killfile-extension/manifest.json
@@ -33,5 +33,5 @@
     "default_title": "Killfile active"
   },
   "manifest_version": 2,
-  "version": "0.2.6"
+  "version": "0.2.7"
 }

--- a/chrome-killfile-extension/scenariolist.js
+++ b/chrome-killfile-extension/scenariolist.js
@@ -178,6 +178,9 @@
                 xpath:"//ol[contains(concat(' ', @class, ' '), ' commentlist ')]/li"}],
       antipope:[{scenario:'mtScenario3',
                  hrefpat:"^[^/]*//(?:[^/]*/)*blog-static/[0-9].*"}],
+      'blox':[{scenario:'bloxPlKateMacScenario',
+                xpath:"//div[@id='SkomentujListaKomentarzy']//div[starts-with(@id,'comment-')]//"
+                + "div[contains(concat(' ', @class, ' '), ' InfoKomentarzAuthor ')]//a"}]
     };
 
     // sbNation.com is really a family of related blogs

--- a/chrome-killfile-extension/scenarios.js
+++ b/chrome-killfile-extension/scenarios.js
@@ -871,6 +871,16 @@
     };
   };
 
+  killfileScenario['bloxPlKateMacScenario'] = function() {
+    return {
+      commenttopxpath: "//div[@id='SkomentujListaKomentarzy']//div[starts-with(@id,'comment-')]",
+      sigbit: "div[contains(concat(' ', @class, ' '), ' InfoKomentarzAuthor ')]/descendant::a[1]",
+      replaceXpath: '.',
+      get mangleAppend() {return this.sigbit + '/parent::*';},
+      __proto__: killfileScenario.basicScenario()
+    };
+  };
+
   function initScenario(scenario) {
     killfileScenario[scenario]().manglePage();
     reviewContent();

--- a/chrome-killfile-extension/scenarios.js
+++ b/chrome-killfile-extension/scenarios.js
@@ -143,7 +143,7 @@
     }
   }
 
-  var kf_debug = true;
+  var kf_debug = false;
 
   function progresslog(logstr) {
     if (kf_debug) {console.log(logstr);}

--- a/firefox-killfile-extension/package.json
+++ b/firefox-killfile-extension/package.json
@@ -8,5 +8,5 @@
   "description": "Provides a killfile for certain blogs' comment sections.",
   "author": "Daniel Martin <martin@snowplow.org>",
   "license": "BSD 2-clause",
-  "version": "0.2.6"
+  "version": "0.2.7"
 }


### PR DESCRIPTION
I read 2 football blogs:
- http://darekwolowski.blox.pl/
- http://rafalstec.blox.pl/

After I started using Killfile I decided to make initial support for Blox.pl platform. It does not handle all blogs on the platform since blogs can use custom templates, but both mentioned blogs use themes from same author, with the same comments' structure. Maybe other blogs too, it doesn't matter.

Fact is, Killfile works correctly on mentioned blogs, so I make pull request. I bumped version too, if you don't mind.
